### PR TITLE
Made deleted posts invisible.

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -14,6 +14,7 @@ async function Home({
 }) {
   const user = await currentUser();
   if (!user) return null;
+  console.log(user);
 
   const userInfo = await fetchUser(user.id);
   if (!userInfo?.onboarded) redirect("/onboarding");

--- a/app/(root)/profile/[id]/page.tsx
+++ b/app/(root)/profile/[id]/page.tsx
@@ -11,7 +11,10 @@ import { fetchUser } from "@/lib/actions/user.actions";
 import ProfileHeader from "@/components/shared/ProfileHeader";
 
 async function Page({ params }: { params: { id: string } }) {
+  
+  
   const user = await currentUser();
+ 
   if (!user) return null;
 
   const userInfo = await fetchUser(params.id);

--- a/app/(root)/thread/[id]/page.tsx
+++ b/app/(root)/thread/[id]/page.tsx
@@ -59,9 +59,10 @@ async function page({ params }: { params: { id: string } }) {
             community={childItem.community}
             createdAt={childItem.createdAt}
             comments={childItem.children}
-            isComment
+            isComment={childItem.parentId}
             tags={childItem.tags}  // Display tags
             likes={childItem.likedBy} // Include likes
+            deleted={childItem.deleted}
           />
         ))}
       </div>

--- a/components/cards/ThreadCard.tsx
+++ b/components/cards/ThreadCard.tsx
@@ -23,6 +23,7 @@ interface Props {
   createdAt: string;
   comments: {
     author: {
+      id : string;
       image: string;
     };
   }[];
@@ -50,6 +51,25 @@ const ThreadCard: React.FC<Props> = ({
   const isCurrentThread = pathname ? pathname.includes(id) : false;
   // Determine if the current user is the author of the thread
   const isAuthor = author && author.id === currentUserId;
+  const authorIds = comments.map(comment => comment.author.id);
+  const isCommentAuthor = authorIds.includes(currentUserId);
+  
+   // Determine if the current path is a profile page and belongs to the comment author
+   const isProfilePage = pathname ? pathname.startsWith('/profile/') : false;
+   const isProfileOwner = isProfilePage && pathname?.includes(currentUserId);
+  if (isProfileOwner){
+    console.log('isprofileowner');
+  }
+  if (isComment) {
+    console.log('isComment');
+  }
+  
+
+   // If the post is deleted, show only on the profile page of the replying user
+   if (deleted && !isProfileOwner && !isAuthor) {
+    console.log('returned null threadcard');
+     return null; // Hide the post from the main view
+   } 
 
   console.log('likes field in ThreadCard.tsx: ', likes);
   return (

--- a/components/forms/Comment.tsx
+++ b/components/forms/Comment.tsx
@@ -24,6 +24,7 @@ interface Props {
   threadId: string;
   currentUserImg: string;
   currentUserId: string;
+
 }
 
 function Comment({ threadId, currentUserImg, currentUserId }: Props) {

--- a/components/shared/ThreadsTab.tsx
+++ b/components/shared/ThreadsTab.tsx
@@ -24,6 +24,7 @@ interface Result {
     likedBy: string[];
     children: {
       author: {
+        id: string;
         image: string;
       };
     }[];
@@ -41,7 +42,6 @@ async function ThreadsTab({ currentUserId, accountId, accountType }: Props) {
   let result: Result | null;
 
   result = await fetchUserPosts(accountId);
-  console.log('likes field in ThreadsTab ', result?.threads);
   if (!result) {
     redirect("/");
     return null;

--- a/lib/actions/thread.actions.ts
+++ b/lib/actions/thread.actions.ts
@@ -57,7 +57,7 @@ export async function fetchPosts(pageNumber = 1, pageSize = 20) {
         populate: {
           path: "author",
           model: User,
-          select: "_id name parentId image",
+          select: "_id id name parentId image",
         },
       });
 

--- a/lib/actions/user.actions.ts
+++ b/lib/actions/user.actions.ts
@@ -84,8 +84,8 @@ export async function fetchUserPosts(userId: string) {
           },
         },
       ],
-    });
-    return threads;
+    }).lean().exec();
+    return threads ? JSON.parse(JSON.stringify(threads)) : null; // Ensure no circular references
   } catch (error) {
     console.error("Error fetching user threads:", error);
     throw error;


### PR DESCRIPTION
Deleted posts will not be shown unless the following:
- Current user is the author of post
- currently in profile page of user

a bit confusing because only parent nodes get shown comments never get shown in homepage, search, and user page.  So when an original post/parent node becomes deleted, only the author of the post can access it through the profile page. I think comments should be shown at least in user page. Also awaitUser() from (root) page.tsx sometimes crashed idk why ;-;